### PR TITLE
Made ifconfig LWRP optional.

### DIFF
--- a/providers/ospf.rb
+++ b/providers/ospf.rb
@@ -41,7 +41,7 @@ action :add do
 
   if new_resource.ifconfig
     ifconfig "#{new_resource.loopback}/32" do
-      device "lo:1"
+      device 'lo:1'
     end
   end
 end

--- a/providers/ospf.rb
+++ b/providers/ospf.rb
@@ -39,9 +39,10 @@ action :add do
     notifies :reload, 'service[quagga]', :delayed
   end
 
-  # configure loopback
-  ifconfig "#{new_resource.loopback}/32" do
-    device 'lo:1'
+  if new_resource.ifconfig
+    ifconfig "#{new_resource.loopback}/32" do
+      device "lo:1"
+    end
   end
 end
 

--- a/resources/ospf.rb
+++ b/resources/ospf.rb
@@ -28,3 +28,4 @@ attribute :protocols, kind_of: Array, default: []
 attribute :loopback, kind_of: String, default: '127.0.0.1'
 attribute :interfaces, kind_of: Hash, default: {}
 attribute :ospf_options, kind_of: Array, default: []
+attribute :ifconfig, :kind_of => [ TrueClass, FalseClass ], :default => true


### PR DESCRIPTION
Ifconfig is incompatible with certain bits of the ip-interface LWRP.  The immediate problem here was specifically how multiple IPs are managed on interfaces / aliases.  Added ability to disable ifconfig LWRP actions.
